### PR TITLE
FUNC: shows copy of screenshot in user window 

### DIFF
--- a/ScreenshotApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ScreenshotApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ScreenshotApp/ScreenshotApp/ContentView.swift
+++ b/ScreenshotApp/ScreenshotApp/ContentView.swift
@@ -8,27 +8,50 @@
 import SwiftUI
 
 struct ContentView: View {
+    
+    @State private var image: NSImage? = nil
+    
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
             
-            Button("Make a screenshot") {
+            // if image has been set (screenshot taken) show image in window
+            if let image = image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+            }
+            
+            // Create a button that prompts the user to take a screenshot
+            Button("Take a screenshot") {
+                
+                // Create a new process called task
                 let task = Process()
+                
+                // Point the task to an already existing macOS command line tool
                 task.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
                 task.arguments = ["-cw"]
                 
+                // Run the task - protect against errors
                 do {
                     try task.run()
                     task.waitUntilExit()
+                    getImageFromPasteboard()
                 } catch {
                     print("could not take screenshot: \(error)")
                 }
             }
         }
         .padding()
+    }
+    
+    // Sets the var image to the image saved to the machine's clipboard
+    func getImageFromPasteboard() {
+     
+        guard NSPasteboard.general.canReadItem(withDataConformingToTypes: NSImage.imageTypes) else { return }
+        
+        guard let image = NSImage(pasteboard: NSPasteboard.general) else { return }
+        
+        self.image = image
     }
 }
 


### PR DESCRIPTION
Changes: Now, when the user presses the 'Take a screenshot button, the screenshot will be displayed in the user's application window'

Author: Rhett Houston

Timestamp: 20:17 in Karin Prater's "Make a MacOS App from Start to Finish with SwiftUI - Screenshot app - PART 1" on YouTube