### PR TITLE
FUNC: Screenshots now appear as grid

### DIFF
--- a/ScreenshotApp/ScreenshotApp.xcodeproj/project.pbxproj
+++ b/ScreenshotApp/ScreenshotApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		C4B11C6C2C505F7C003C5554 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B11C6B2C505F7C003C5554 /* ContentView.swift */; };
 		C4B11C6E2C505F7D003C5554 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C4B11C6D2C505F7D003C5554 /* Assets.xcassets */; };
 		C4B11C712C505F7D003C5554 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C4B11C702C505F7D003C5554 /* Preview Assets.xcassets */; };
+		C4B11C792C5069C1003C5554 /* ScreenCapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B11C782C5069C1003C5554 /* ScreenCapViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -20,6 +21,7 @@
 		C4B11C6D2C505F7D003C5554 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C4B11C702C505F7D003C5554 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		C4B11C722C505F7D003C5554 /* ScreenshotApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ScreenshotApp.entitlements; sourceTree = "<group>"; };
+		C4B11C782C5069C1003C5554 /* ScreenCapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,6 +55,7 @@
 			isa = PBXGroup;
 			children = (
 				C4B11C692C505F7C003C5554 /* ScreenshotAppApp.swift */,
+				C4B11C782C5069C1003C5554 /* ScreenCapViewModel.swift */,
 				C4B11C6B2C505F7C003C5554 /* ContentView.swift */,
 				C4B11C6D2C505F7D003C5554 /* Assets.xcassets */,
 				C4B11C722C505F7D003C5554 /* ScreenshotApp.entitlements */,
@@ -140,6 +143,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C4B11C6C2C505F7C003C5554 /* ContentView.swift in Sources */,
+				C4B11C792C5069C1003C5554 /* ScreenCapViewModel.swift in Sources */,
 				C4B11C6A2C505F7C003C5554 /* ScreenshotAppApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ScreenshotApp/ScreenshotApp/ContentView.swift
+++ b/ScreenshotApp/ScreenshotApp/ContentView.swift
@@ -9,13 +9,12 @@ import SwiftUI
 
 struct ContentView: View {
     
-    @State private var image: NSImage? = nil
+    @StateObject var vm = ScreenCapViewModel()
     
     var body: some View {
         VStack {
             
-            // if image has been set (screenshot taken) show image in window
-            if let image = image {
+            ForEach(vm.images, id: \.self) { image in
                 Image(nsImage: image)
                     .resizable()
                     .scaledToFit()
@@ -23,35 +22,10 @@ struct ContentView: View {
             
             // Create a button that prompts the user to take a screenshot
             Button("Take a screenshot") {
-                
-                // Create a new process called task
-                let task = Process()
-                
-                // Point the task to an already existing macOS command line tool
-                task.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
-                task.arguments = ["-cw"]
-                
-                // Run the task - protect against errors
-                do {
-                    try task.run()
-                    task.waitUntilExit()
-                    getImageFromPasteboard()
-                } catch {
-                    print("could not take screenshot: \(error)")
-                }
+                vm.takeScreenshot()
             }
         }
         .padding()
-    }
-    
-    // Sets the var image to the image saved to the machine's clipboard
-    func getImageFromPasteboard() {
-     
-        guard NSPasteboard.general.canReadItem(withDataConformingToTypes: NSImage.imageTypes) else { return }
-        
-        guard let image = NSImage(pasteboard: NSPasteboard.general) else { return }
-        
-        self.image = image
     }
 }
 

--- a/ScreenshotApp/ScreenshotApp/ScreenCapViewModel.swift
+++ b/ScreenshotApp/ScreenshotApp/ScreenCapViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  ScreenCapViewModel.swift
+//  ScreenshotApp
+//
+//  Created by Rhett Houston  on 7/23/24.
+//
+
+import SwiftUI
+
+class ScreenCapViewModel: ObservableObject {
+    
+    @Published var images = [NSImage]()
+    
+    func takeScreenshot() {
+        // Create a new process called task
+        let task = Process()
+        
+        // Point the task to an already existing macOS command line tool
+        task.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+        task.arguments = ["-cw"]
+        
+        // Run the task - protect against errors
+        do {
+            try task.run()
+            task.waitUntilExit()
+            getImageFromPasteboard()
+        } catch {
+            print("could not take screenshot: \(error)")
+        }
+    }
+    
+    private func getImageFromPasteboard() {
+        guard NSPasteboard.general.canReadItem(withDataConformingToTypes: NSImage.imageTypes) else { return }
+        
+        guard let image = NSImage(pasteboard: NSPasteboard.general) else { return }
+        
+        self.images.append(image)
+    }
+    
+}


### PR DESCRIPTION
Changes: When the user takes a screenshot, it now appears as if it were in an array with previous screenshots taken. Further UI refinements should be implemented to more efficiently use window space. 

Author: Rhett Houston

Timestamp: 23:47 of Karin Prater's "Make a MacOS App from Start to Finish with SwiftUI - Screenshot app - PART 1" on Youtube